### PR TITLE
file_fusion.pyで結合するファイルを日付順にソートする

### DIFF
--- a/file_fusion.py
+++ b/file_fusion.py
@@ -35,6 +35,7 @@ def process(dirPath):
         fpath = os.path.join(dirPath, men)
         if os.path.isdir(fpath):                # 直下のフォルダを対象として処理
             fileList =  glob.glob(dirPath + "/" + men + '/*.csv')   # CSVファイルのリストを作成
+            fileList = sorted(fileList)
             for fname in fileList:
                 bname = os.path.basename(fname)
                 if(bname != saveFileName):


### PR DESCRIPTION
file_fusion.pyでファイルを結合する際、対象ファイルのソートを実施していないため、結合結果の並びが不安定になることがあります。

globの結果をsortすることで常に時刻順に並ぶよう修正しています。